### PR TITLE
Add an update feature (previously only insert was allowed) but it add…

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,24 @@
 ## requirements
 
 You need PHP (7.x), composer, and Symfony 4
+Even if i didn't try without ApiPlatform, it should work without this component. We only use ValidationException from ApiPlatform Sf bridge because ApiPlatform rely on it to return HTTP 4x error.
+If your Api doesn't rely on this component, you will just have to add a listener on this kind of exception to manage the Response.   
 
 ## explanation
 
 Working with ApiPlatform, i wanted to use custom POST route where i could send complex json data which represents nested entities.
 To realize this i choose to use the ParamConverters. So with little convention (json props must be the same as php entity props)
 and few ParamConverters (one per entity) extending the Rebolon/Request/ItemAbstractConverter (for one entity) or ListAbstractConverter (for collection of entities), it works !
+
+For instance it works finely in **Creation** mode.
+Also, when you send sub-entities with all properties even an ID, then, the component consider that you want to use the existing entity with the specified ID.
+It will then ignore all other fields. This is a security to prevent update on sub-entities. But maybe this feature is missing and in this case, open an issue ! 
+
+When you do a PUT HTTP, only the rot entity will be updated. If you have nested entities with associative entities, it's up to you to manage the wished behavior in the Controller.
+The ParamConverter will not take any decision so:
+ * if you already have entries in this kind of relations, they will be kept, and those you specified in the JSON will be added
+ * if you want to replace those relations with the new ones, you will have to delete them (all relations that have ID are the old ones) in the Controller before persist the Book entity
+ * if you want to update those relations
 
 Here are some samples of json sent to the custom routes:
 

--- a/src/Request/ParamConverter/ItemAbstractConverter.php
+++ b/src/Request/ParamConverter/ItemAbstractConverter.php
@@ -14,6 +14,11 @@ use Symfony\Component\Validator\ConstraintViolationList;
 abstract class ItemAbstractConverter extends AbstractConverter
 {
     /**
+     * only root element can be updated, all nested entities won't be even if they have ID. All other fields of thoses entities will be forgiven
+     */
+    const ROOT_LIMIT_FOR_UPDATE = 1;
+
+    /**
      * @inheritdoc
      */
     public function initFromRequest($jsonOrArray, $propertyPath)
@@ -24,23 +29,31 @@ abstract class ItemAbstractConverter extends AbstractConverter
             $json = $this->checkJsonOrArray($jsonOrArray);
 
             $idPropertyIsInJson = false;
+            $entity = null;
             if (!is_array($json)
                 || ($idPropertyIsInJson = array_key_exists($this->getIdProperty(), $json))
             ) {
-                /**
-                 * We don't care of other properties. We don't accept update on sub-entity, we can create or re-use
-                 * So here we just clean json and replace it with the id content
-                 */
-                if ($idPropertyIsInJson) {
-                    $json = $json[$this->getIdProperty()];
+
+                if (count(self::$propertyPath) > self::ROOT_LIMIT_FOR_UPDATE) {
+                    /**
+                     * We don't care of other properties. We don't accept update on sub-entity, we can create or re-use
+                     * So here we just clean json and replace it with the id content
+                     */
+                    if ($idPropertyIsInJson) {
+                        $json = $json[$this->getIdProperty()];
+                    }
+
+                    array_pop(self::$propertyPath);
+
+                    return $this->getFromDatabase($json);
                 }
 
-                array_pop(self::$propertyPath);
-
-                return $this->getFromDatabase($json);
+                if ($idPropertyIsInJson) {
+                    $entity = $this->getFromDatabase($json[$this->getIdProperty()], static::RELATED_ENTITY);
+                }
             }
 
-            $entity = $this->buildEntity($json);
+            $entity = $this->buildEntity($json, $entity);
 
             array_pop(self::$propertyPath);
 

--- a/tests/ApiJsonParamConverterTest.php
+++ b/tests/ApiJsonParamConverterTest.php
@@ -102,6 +102,7 @@ JSON;
         $entityManager = $this->createMock(EntityManagerInterface::class);
         $bookConverter = $this->getBookConverter($entityManager);
 
+        $bookConverter->setInsertMode();
         $book = $bookConverter->initFromRequest(json_encode($content->book), 'book');
 
         $this->assertEquals($content->book->title, $book->getTitle());
@@ -141,6 +142,7 @@ JSON;
 
         $bookConverter = $this->getBookConverter($entityManager);
 
+        $bookConverter->setInsertMode();
         $book = $bookConverter->initFromRequest(json_encode($content->book), 'book');
 
         $this->assertEquals($content->book->title, $book->getTitle());
@@ -169,6 +171,7 @@ JSON;
 
         $bookConverter = $this->getBookConverter($entityManager);
 
+        $bookConverter->setInsertMode();
         $book = $bookConverter->initFromRequest(json_encode($content->book), 'book');
 
         $this->assertEquals($content->book->title, $book->getTitle());
@@ -188,6 +191,7 @@ JSON;
 
         $bookConverter = $this->getBookConverter($entityManager);
 
+        $bookConverter->setInsertMode();
         $bookConverter->initFromRequest(json_encode($content->book), 'book');
     }
 


### PR DESCRIPTION
…s more complexity: should i allow update of all nodes when an id is set or only root element of the json string ? what happens on associative entity (ParamConverter must not remove DB entries, so the controller will have to manage this) ? should i block this feature when this is an HTTP POST call ?